### PR TITLE
Gnome 45.1: Move imports to the top

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import Gio from "gi://Gio";
 import Gtk from "gi://Gtk";
 import Gdk from "gi://Gdk";
@@ -7,6 +5,8 @@ import GLib from "gi://GLib";
 import Adw from "gi://Adw";
 
 import { ExtensionPreferences, gettext as _ } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
+
+"use strict";
 
 Gio._promisify(Gio.File.prototype, "query_info_async");
 Gio._promisify(Gio.File.prototype, "enumerate_children_async");


### PR DESCRIPTION
Hi! First of all - thank you for the extension!

I've just upgraded to Fedora 39 with Gnome 45.1, and the extension won't start (and I realised how much I miss it, lol).
It said that imports must be on the top (prefs.js file).

I also noticed the `dbus.js` file also has "use strict" on the top, but it doesn't break the startup for some reason.