### PR TITLE
GNOME 46 compatibility

### DIFF
--- a/src/helpers/shell/PanelButton.ts
+++ b/src/helpers/shell/PanelButton.ts
@@ -568,7 +568,7 @@ class PanelButton extends PanelMenu.Button {
         tapAction.connect("tap", onClick);
         icon.add_action(tapAction);
 
-        const oldIcon = this.menuControls.find_child_by_name(options.name);
+        const oldIcon = this.menuControls.get_child_at_index(options.menuProps.index);
 
         if (oldIcon?.get_parent() === this.menuControls) {
             this.menuControls.replace_child(oldIcon, icon);
@@ -716,7 +716,7 @@ class PanelButton extends PanelMenu.Button {
 
         icon.add_action(tapAction);
 
-        const oldIcon = this.buttonControls.find_child_by_name(options.name);
+        const oldIcon = this.buttonControls.get_child_at_index(options.panelProps.index);
 
         if (oldIcon != null) {
             this.buttonControls.replace_child(oldIcon, icon);
@@ -726,7 +726,7 @@ class PanelButton extends PanelMenu.Button {
     }
 
     private removeButtonControlIcon(options: ControlIconOptions) {
-        const icon = this.buttonControls.find_child_by_name(options.name);
+        const icon = this.buttonControls.get_child_at_index(options.menuProps.index);
 
         if (icon != null) {
             this.buttonControls.remove_child(icon);

--- a/src/helpers/shell/ScrollingLabel.ts
+++ b/src/helpers/shell/ScrollingLabel.ts
@@ -64,7 +64,11 @@ class ScrollingLabel extends St.ScrollView {
 
         this.onShowChangedId = this.label.connect("show", this.onShowChanged.bind(this));
         this.box.add_child(this.label);
-        this.add_actor(this.box);
+        if (Clutter.Container === undefined) {
+            this.add_child(this.box);
+        } else {
+            this.add_actor(this.box);
+        }
     }
 
     public pauseScrolling() {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,6 +5,6 @@
   "url": "https://github.com/cliffniff/media-controls",
   "settings-schema": "org.gnome.shell.extensions.mediacontrols",
   "gettext-domain": "mediacontrols@cliffniff.github.com",
-  "version-name": "2.0.0",
-  "shell-version": ["45"]
+  "version-name": "2.0.1",
+  "shell-version": ["45", "46"]
 }


### PR DESCRIPTION
gnome 46 is in beta which means interfaces are frozen - I updated already the 3 other extensions I maintain.
one thing i noticed is they removed add_actor / remove_actor in favor of add_child / remove_child
