### PR TITLE
Add extended panel position options

### DIFF
--- a/assets/org.gnome.shell.extensions.mediacontrols.gschema.xml
+++ b/assets/org.gnome.shell.extensions.mediacontrols.gschema.xml
@@ -18,8 +18,10 @@
   </enum>
   <enum id="org.gnome.shell.extensions.mediacontrols.positions">
     <value nick="Left" value="0" />
-    <value nick="Center" value="1" />
-    <value nick="Right" value="2" />
+    <value nick="RightMostLeft" value="1" />
+    <value nick="Center" value="2" />
+    <value nick="LeftMostRight" value="3" />
+    <value nick="Right" value="4" />
   </enum>
   <schema id="org.gnome.shell.extensions.mediacontrols" path="/org/gnome/shell/extensions/mediacontrols/">
     <key name="label-width" type="u">

--- a/assets/ui/prefs.ui
+++ b/assets/ui/prefs.ui
@@ -189,7 +189,9 @@
               <object class="GtkStringList">
                 <items>
                   <item translatable="yes">Left</item>
+                  <item translatable="yes">Rightmost Left</item>
                   <item translatable="yes">Center</item>
+                  <item translatable="yes">Leftmost Right</item>
                   <item translatable="yes">Right</item>
                 </items>
               </object>

--- a/src/extension.js
+++ b/src/extension.js
@@ -657,7 +657,7 @@ export default class MediaControls extends Extension {
             Main.panel.statusArea.dateMenu._messageList._messageView._mediaSource._onProxyReady();
         } else {
             this.mediaSectionAddFunc = Mpris.MprisSource.prototype._addPlayer;
-            Mpris.MprisSource.prototype._addPlayer = function () { };
+            Mpris.MprisSource.prototype._addPlayer = function () {};
             // @ts-expect-error
             if (Main.panel.statusArea.dateMenu._messageList._messageView._mediaSource._players != null) {
                 // @ts-expect-error

--- a/src/extension.js
+++ b/src/extension.js
@@ -657,7 +657,7 @@ export default class MediaControls extends Extension {
             Main.panel.statusArea.dateMenu._messageList._messageView._mediaSource._onProxyReady();
         } else {
             this.mediaSectionAddFunc = Mpris.MprisSource.prototype._addPlayer;
-            Mpris.MprisSource.prototype._addPlayer = function () {};
+            Mpris.MprisSource.prototype._addPlayer = function () { };
             // @ts-expect-error
             if (Main.panel.statusArea.dateMenu._messageList._messageView._mediaSource._players != null) {
                 // @ts-expect-error
@@ -685,7 +685,41 @@ export default class MediaControls extends Extension {
             return;
         }
         this.panelBtn = new PanelButton(playerProxy, this);
-        Main.panel.addToStatusArea("Media Controls", this.panelBtn, this.extensionIndex, this.extensionPosition);
+
+        // Handle special positions
+        let position;
+        let index = this.extensionIndex;
+
+        switch (this.extensionPosition) {
+            case ExtensionPositions.LEFT:
+                position = "left";
+                // Use custom index, or 0 for leftmost in left section
+                break;
+            case ExtensionPositions.RIGHTMOST_LEFT:
+                position = "left";
+                index = -1; // Rightmost position in left section
+                break;
+            case ExtensionPositions.CENTER:
+                position = "center";
+                // Use custom index
+                break;
+            case ExtensionPositions.LEFTMOST_RIGHT:
+                position = "right";
+                index = 0; // Leftmost position in right section
+                break;
+            case ExtensionPositions.RIGHT:
+                position = "right";
+                // For right section, if index is 0 (default), use -1 to place at rightmost
+                if (index === 0) {
+                    index = -1;
+                }
+                break;
+            default:
+                position = "right";
+                break;
+        }
+
+        Main.panel.addToStatusArea("Media Controls", this.panelBtn, index, position);
     }
 
     /**

--- a/src/types/enums/common.js
+++ b/src/types/enums/common.js
@@ -27,7 +27,9 @@ export const LoopStatus = {
 };
 export const ExtensionPositions = {
     LEFT: "left",
+    RIGHTMOST_LEFT: "rightmost-left",
     CENTER: "center",
+    LEFTMOST_RIGHT: "leftmost-right",
     RIGHT: "right",
 };
 export const LabelTypes = {


### PR DESCRIPTION
Add two new position options for more precise panel placement:
- Rightmost Left: Places extension at the rightmost position in the left section
- Leftmost Right: Places extension at the leftmost position in the right section

This provides users with 5 position options ordered logically from left to right:
1. Left - Left section with custom index
2. Rightmost Left - Rightmost position in left section
3. Center - Center section with custom index
4. Leftmost Right - Leftmost position in right section
5. Right - Right section (defaults to rightmost when index is 0)

Changes:
- Updated schema to add new position enum values
- Updated preferences UI to show new options in logical order
- Enhanced position handling logic in extension.js
- Added unique enum values to distinguish between positions

Fix: #230 