### PR TITLE
Fix gfileinfo icon warning

### DIFF
--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -438,7 +438,12 @@ class PanelButton extends PanelMenu.Button {
             if (trackUri != null && trackUri.get_scheme() === "file") {
                 const file = Gio.File.new_for_uri(trackUri.to_string());
                 const info = await file
-                    .query_info_async(Gio.FILE_ATTRIBUTE_THUMBNAIL_PATH, Gio.FileQueryInfoFlags.NONE, null, null)
+                    .query_info_async(
+                        `${Gio.FILE_ATTRIBUTE_THUMBNAIL_PATH},${Gio.FILE_ATTRIBUTE_STANDARD_ICON}`,
+                        Gio.FileQueryInfoFlags.NONE,
+                        null,
+                        null,
+                    )
                     .catch(handleError);
                 if (info != null) {
                     const path = info.get_attribute_byte_string(Gio.FILE_ATTRIBUTE_THUMBNAIL_PATH);


### PR DESCRIPTION
When querying file info for thumbnails, we need to request the standard::icon attribute if we plan to call get_icon() on the GFileInfo object. This fixes the warning: 'GFileInfo created without standard::icon'