### PR TITLE
Fix memory leak in addMenuPlayers() when recreating player icons

### DIFF
--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -1074,6 +1074,7 @@ class PanelButton extends PanelMenu.Button {
         this.menuPlayers = null;
         this.menuImage = null;
         this.menuLabels = null;
+        this.menuSlider?.destroy();
         this.menuSlider = null;
         this.menuControls = null;
         this.menuPlayersTextBox = null;

--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -344,10 +344,11 @@ class PanelButton extends PanelMenu.Button {
                 styleClass: "popup-menu-player-icons",
             });
         } else if (players.length === 1 && this.menuPlayerIcons != null) {
+            this.menuPlayerIcons.get_children().forEach((child) => child.destroy());
             this.menuPlayers.remove_child(this.menuPlayerIcons);
             this.menuPlayerIcons = null;
-        } else {
-            this.menuPlayerIcons?.remove_all_children();
+        } else if (this.menuPlayerIcons != null) {
+            this.menuPlayerIcons.get_children().forEach((child) => child.destroy());
         }
         const isPinned = this.playerProxy.isPlayerPinned();
         this.menuPlayersTextBoxPin.opacity = isPinned ? 255 : 160;
@@ -1079,6 +1080,9 @@ class PanelButton extends PanelMenu.Button {
         this.menuPlayersTextBoxIcon = null;
         this.menuPlayersTextBoxLabel = null;
         this.menuPlayersTextBoxPin = null;
+        if (this.menuPlayerIcons != null) {
+            this.menuPlayerIcons.get_children().forEach((child) => child.destroy());
+        }
         this.menuPlayerIcons = null;
         this.menuLabelTitle = null;
         this.menuLabelSubtitle = null;


### PR DESCRIPTION
## Problem
When player icons are recreated in `addMenuPlayers()`, new signal connections are made but old icons aren't properly destroyed, causing memory leaks.

## Solution
This PR ensures that all child icons are properly destroyed before being removed from the container:
- Calls `child.destroy()` on each icon before removal
- Applies cleanup in both the update path and the `onDestroy()` method
- Properly disconnects signal connections when icons are destroyed

## Impact
- Fixes memory leaks when players are added/removed
- Fixes memory leaks when the extension is disabled
- Improves overall extension stability and performance