### PR TITLE
Fix buttonControls widget cleanup to prevent memory leaks

### DIFF
--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -285,6 +285,7 @@ class PanelButton extends PanelMenu.Button {
                     this.addButtonControls(i, flags);
                 } else if (this.buttonControls != null) {
                     this.buttonBox.remove_child(this.buttonControls);
+                    this.buttonControls.destroy();
                     this.buttonControls = null;
                 }
             }


### PR DESCRIPTION
The commit adds a cleanup step by destroying buttonControls after removing it from the UI, improving resource management.