### PR TITLE
Fix memory leak: Remove old proxy listeners before updating to new player

### DIFF
--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -216,6 +216,7 @@ class PanelButton extends PanelMenu.Button {
     updateProxy(playerProxy) {
         if (this.isSamePlayer(playerProxy) === false) {
             debugLog(`Updating proxy to ${playerProxy.busName}`);
+            this.removeProxyListeners();
             this.playerProxy = playerProxy;
             this.updateWidgets(WidgetFlags.ALL);
             this.addProxyListeners();
@@ -891,7 +892,6 @@ class PanelButton extends PanelMenu.Button {
      * @returns {void}
      */
     addProxyListeners() {
-        this.removeProxyListeners();
         this.addProxyListener("Metadata", () => {
             this.updateWidgets(
                 WidgetFlags.PANEL_LABEL | WidgetFlags.MENU_IMAGE | WidgetFlags.MENU_LABELS | WidgetFlags.MENU_SLIDER,


### PR DESCRIPTION
## Problem
When `updateProxy()` was called with a new player, old listeners remained attached to the old proxy. This happened because:

1. `updateProxy()` would update `this.playerProxy` to point to the new proxy
2. Then call `addProxyListeners()` which internally called `removeProxyListeners()`
3. But `removeProxyListeners()` was trying to remove listeners from the already-updated `this.playerProxy` reference (the new proxy)
4. The old proxy's listeners were never cleaned up, causing a memory leak

## Solution
- Call `removeProxyListeners()` **before** updating the `this.playerProxy` reference in `updateProxy()`
- Remove the redundant `removeProxyListeners()` call from inside `addProxyListeners()`

This ensures proper cleanup of listeners when switching between players.

## Changes
- Modified `updateProxy()` to call `removeProxyListeners()` before updating the proxy reference
- Removed redundant `removeProxyListeners()` call from `addProxyListeners()`