### PR TITLE
Fix theme node warnings in ScrollingLabel

### DIFF
--- a/src/helpers/shell/ScrollingLabel.js
+++ b/src/helpers/shell/ScrollingLabel.js
@@ -99,7 +99,7 @@ class ScrollingLabel extends St.ScrollView {
             yAlign: Clutter.ActorAlign.CENTER,
             xAlign: Clutter.ActorAlign.START,
         });
-        this.onShowChangedId = this.label.connect("show", this.onShowChanged.bind(this));
+        this.onShowChangedId = this.label.connect("notify::mapped", this.onShowChanged.bind(this));
         this.box.add_child(this.label);
         this.add_child(this.box);
     }
@@ -181,7 +181,8 @@ class ScrollingLabel extends St.ScrollView {
      * @returns {void}
      */
     onShowChanged() {
-        if (this.label.visible === false) {
+        // Only proceed if widget is mapped (visible and in stage)
+        if (this.label.mapped === false) {
             return;
         }
         const isLabelWider = this.label.width > this.labelWidth && this.labelWidth > 0;


### PR DESCRIPTION
Fixes warnings: 'st_widget_get_theme_node called on the widget which is not in the stage'

The issue occurred when accessing widget.width before the widget was fully added to the stage hierarchy. This happened because the 'show' signal can fire before the widget is mapped to the stage.

Changes:
- Changed signal from 'show' to 'notify::mapped'
- Updated check to verify widget is mapped before accessing theme properties
- The 'mapped' property is only true when widget is visible AND in stage

This ensures theme properties are only accessed when it's safe to do so.