### PR TITLE
Fix ScrollingLabel allocation errors

### DIFF
--- a/src/helpers/shell/ScrollingLabel.js
+++ b/src/helpers/shell/ScrollingLabel.js
@@ -1,9 +1,31 @@
 import Clutter from "gi://Clutter";
 import GObject from "gi://GObject";
+import GLib from "gi://GLib";
 import Pango from "gi://Pango";
 import St from "gi://St";
 
 const SCROLL_ANIMATION_SPEED = 0.04;
+
+/**
+ * Check if an actor is properly allocated and ready for operations
+ * @param {any} actor - The Clutter actor to check
+ * @returns {boolean}
+ */
+const isActorProperlyAllocated = (actor) => {
+    if (!actor) {
+        return false;
+    }
+
+    const mapped = actor.mapped;
+    const visible = actor.visible;
+    const hasAllocation = actor.has_allocation();
+    const allocationBox = hasAllocation ? actor.get_allocation_box() : null;
+    const hasWidth = allocationBox ? (allocationBox.x2 - allocationBox.x1) > 0 : false;
+    const hasHeight = allocationBox ? (allocationBox.y2 - allocationBox.y1) > 0 : false;
+    const hasParent = actor.get_parent() !== null;
+
+    return mapped && visible && hasAllocation && hasWidth && hasHeight && hasParent;
+};
 
 /**
  * @typedef {Object} ScrollingLabelParams
@@ -55,6 +77,11 @@ class ScrollingLabel extends St.ScrollView {
     initPaused;
     /**
      * @private
+     * @type {boolean}
+     */
+    isInitiallyVisible;
+    /**
+     * @private
      * @type {number}
      */
     labelWidth;
@@ -88,6 +115,7 @@ class ScrollingLabel extends St.ScrollView {
         this.isScrolling = isScrolling;
         this.isFixedWidth = isFixedWidth;
         this.initPaused = initPaused;
+        this.isInitiallyVisible = false;
         this.labelWidth = width;
         this.direction = direction;
         this.box = new St.BoxLayout({
@@ -99,7 +127,7 @@ class ScrollingLabel extends St.ScrollView {
             yAlign: Clutter.ActorAlign.CENTER,
             xAlign: Clutter.ActorAlign.START,
         });
-        this.onShowChangedId = this.label.connect("show", this.onShowChanged.bind(this));
+        this.onShowChangedId = this.label.connect("notify::mapped", this.onShowChanged.bind(this));
         this.box.add_child(this.label);
         this.add_child(this.box);
     }
@@ -127,7 +155,48 @@ class ScrollingLabel extends St.ScrollView {
      * @returns {void}
      */
     initScrolling() {
+        // Ensure the widget is on the stage before proceeding with scrolling animation
+        if (!this.mapped || !this.label.mapped) {
+            // If not mapped yet, wait until it is before initializing scrolling
+            GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+                if (this.mapped && this.label.mapped) {
+                    this.doInitScrolling();
+                    return GLib.SOURCE_REMOVE;
+                }
+                return GLib.SOURCE_CONTINUE;
+            });
+        } else {
+            this.doInitScrolling();
+        }
+    }
+
+    doInitScrolling() {
+        // Check if the actors are properly allocated before initializing scrolling
+        const scrollViewProperlyAllocated = isActorProperlyAllocated(this);
+        const labelProperlyAllocated = isActorProperlyAllocated(this.label);
+        const boxProperlyAllocated = isActorProperlyAllocated(this.box);
+
+        if (!scrollViewProperlyAllocated || !labelProperlyAllocated || !boxProperlyAllocated) {
+            GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+                if (isActorProperlyAllocated(this) &&
+                    isActorProperlyAllocated(this.label) &&
+                    isActorProperlyAllocated(this.box)) {
+                    this.reallyDoInitScrolling();
+                    return GLib.SOURCE_REMOVE;
+                }
+                return GLib.SOURCE_CONTINUE;
+            });
+            return;
+        }
+
+        this.reallyDoInitScrolling();
+    }
+
+    reallyDoInitScrolling() {
         const adjustment = this.get_hadjustment();
+        if (!adjustment) {
+            return;
+        }
         const origText = this.label.text + "     ";
         this.onAdjustmentChangedId = adjustment.connect(
             "changed",
@@ -147,33 +216,84 @@ class ScrollingLabel extends St.ScrollView {
         if (adjustment.upper <= adjustment.pageSize) {
             return;
         }
-        const initial = new GObject.Value();
-        initial.init(GObject.TYPE_INT);
-        initial.set_int(adjustment.value);
-        const final = new GObject.Value();
-        final.init(GObject.TYPE_INT);
-        final.set_int(adjustment.upper);
-        const duration = adjustment.upper / SCROLL_ANIMATION_SPEED;
-        const pspec = adjustment.find_property("value");
-        const interval = new Clutter.Interval({
-            valueType: pspec.value_type,
-            initial,
-            final,
-        });
-        this.transition = new Clutter.PropertyTransition({
-            propertyName: "value",
-            progressMode: Clutter.AnimationMode.LINEAR,
-            direction: this.direction,
-            repeatCount: -1,
-            duration,
-            interval,
-        });
-        this.label.text = `${origText} ${origText}`;
-        adjustment.add_transition("scroll", this.transition);
-        adjustment.disconnect(this.onAdjustmentChangedId);
-        if (this.initPaused) {
-            this.transition.pause();
+
+        // Check if the actor is on the stage before creating animations
+        const onStage = this.get_stage() !== null;
+        if (!onStage || !this.mapped || !this.label.mapped || !isActorProperlyAllocated(this) || !isActorProperlyAllocated(this.label)) {
+            // Retry after a small delay if not properly allocated
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+                const nowOnStage = this.get_stage() !== null;
+                if (nowOnStage && this.mapped && this.label.mapped &&
+                    isActorProperlyAllocated(this) &&
+                    isActorProperlyAllocated(this.label)) {
+                    this.createScrollTransition(adjustment, origText);
+                    return GLib.SOURCE_REMOVE;
+                }
+                return GLib.SOURCE_CONTINUE;
+            });
+            return;
         }
+
+        this.createScrollTransition(adjustment, origText);
+    }
+
+    createScrollTransition(adjustment, origText) {
+        // Ensure we're on stage before creating transitions
+        if (!this.get_stage()) {
+            return;
+        }
+
+        // Disconnect the adjustment signal first
+        adjustment.disconnect(this.onAdjustmentChangedId);
+
+        // Defer all modifications to avoid triggering relayout during allocation
+        GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+            if (!this.get_stage() || !adjustment) {
+                return GLib.SOURCE_REMOVE;
+            }
+
+            // Update the label text to duplicate it for scrolling
+            this.label.text = `${origText} ${origText}`;
+
+            // Wait one more frame for the text change to be processed
+            GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+                if (!this.get_stage() || !adjustment) {
+                    return GLib.SOURCE_REMOVE;
+                }
+
+                const initial = new GObject.Value();
+                initial.init(GObject.TYPE_INT);
+                initial.set_int(adjustment.value);
+                const final = new GObject.Value();
+                final.init(GObject.TYPE_INT);
+                final.set_int(adjustment.upper);
+                const duration = adjustment.upper / SCROLL_ANIMATION_SPEED;
+                const pspec = adjustment.find_property("value");
+                const interval = new Clutter.Interval({
+                    valueType: pspec.value_type,
+                    initial,
+                    final,
+                });
+                this.transition = new Clutter.PropertyTransition({
+                    propertyName: "value",
+                    progressMode: Clutter.AnimationMode.LINEAR,
+                    direction: this.direction,
+                    repeatCount: -1,
+                    duration,
+                    interval,
+                });
+
+                adjustment.add_transition("scroll", this.transition);
+
+                if (this.initPaused) {
+                    this.transition.pause();
+                }
+
+                return GLib.SOURCE_REMOVE;
+            });
+
+            return GLib.SOURCE_REMOVE;
+        });
     }
 
     /**
@@ -181,21 +301,49 @@ class ScrollingLabel extends St.ScrollView {
      * @returns {void}
      */
     onShowChanged() {
-        if (this.label.visible === false) {
+        if (!this.label.mapped) {
             return;
         }
-        const isLabelWider = this.label.width > this.labelWidth && this.labelWidth > 0;
-        if (isLabelWider && this.isScrolling) {
-            this.initScrolling();
+
+        // Only proceed if we haven't initialized yet
+        if (this.isInitiallyVisible) {
+            return;
         }
-        if (this.isFixedWidth && this.labelWidth > 0) {
-            this.box.width = this.labelWidth;
-            this.label.xAlign = Clutter.ActorAlign.CENTER;
-            this.label.xExpand = true;
-        } else if (isLabelWider) {
-            this.box.width = Math.min(this.label.width, this.labelWidth);
-        }
-        this.label.disconnect(this.onShowChangedId);
+
+        this.isInitiallyVisible = true;
+
+        // Use GLib.idle_add to ensure the widget is properly allocated before proceeding
+        GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+            if (this.label && this.labelWidth > 0) {
+                // Get the allocation box to determine the actual width safely
+                const labelAlloc = this.label.get_allocation_box();
+                const labelWidth = labelAlloc ? (labelAlloc.x2 - labelAlloc.x1) : 0;
+
+                // Only proceed if we have a valid label width
+                if (labelWidth > 0) {
+                    const isLabelWider = labelWidth > this.labelWidth && this.labelWidth > 0;
+
+                    if (isLabelWider && this.isScrolling) {
+                        this.initScrolling();
+                    }
+
+                    if (this.isFixedWidth && this.labelWidth > 0) {
+                        this.box.width = this.labelWidth;
+                        this.label.xAlign = Clutter.ActorAlign.CENTER;
+                        this.label.xExpand = true;
+                    } else if (isLabelWider) {
+                        this.box.width = Math.min(labelWidth, this.labelWidth);
+                    }
+                }
+            }
+
+            // Disconnect the signal after we've initialized
+            if (this.label && this.onShowChangedId) {
+                this.label.disconnect(this.onShowChangedId);
+            }
+
+            return GLib.SOURCE_REMOVE;
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR fixes the allocation errors in ScrollingLabel that were causing console warnings:
- 'Timelines with detached actors are not supported'
- 'Can't update stage views actor... needs an allocation'

## Changes
- Added proper stage and allocation checks before creating animations
- Implemented double idle_add pattern to defer text changes and transitions until after allocation completes
- Changed signal from 'show' to 'notify::mapped' for better lifecycle tracking
- Added isActorProperlyAllocated helper function to verify actor readiness
- Split initialization into multiple stages (initScrolling → doInitScrolling → reallyDoInitScrolling) to ensure proper allocation

## Testing
Tested with media playback in Firefox - scrolling labels now animate smoothly without triggering allocation warnings.