### PR TITLE
Fix excessive logging and eliminate duplicate 'Chosen player' log entry

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -566,7 +566,6 @@ export default class MediaControls extends Extension {
             });
             this.playerProxies.set(busName, playerProxy);
             this.panelBtn?.updateWidgets(WidgetFlags.MENU_PLAYERS);
-            this.setActivePlayer();
         } catch (e) {
             errorLog("Failed to add player:", busName, e);
         }

--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -447,8 +447,8 @@ class PanelButton extends PanelMenu.Button {
         }
         if (this.menuPlayers.get_parent() == null) {
             this.menuBox.add_child(this.menuPlayers);
+            debugLog("Added menu players");
         }
-        debugLog("Added menu players");
     }
 
     /**
@@ -517,8 +517,8 @@ class PanelButton extends PanelMenu.Button {
         }
         if (this.menuImage.get_parent() == null) {
             this.menuBox.insert_child_above(this.menuImage, this.menuPlayers);
+            debugLog("Added menu image");
         }
-        debugLog("Added menu image");
     }
 
     /**
@@ -560,8 +560,8 @@ class PanelButton extends PanelMenu.Button {
         this.menuLabels.add_child(this.menuLabelSubtitle);
         if (this.menuLabels.get_parent() == null) {
             this.menuBox.add_child(this.menuLabels);
+            debugLog("Added menu labels");
         }
-        debugLog("Added menu labels");
     }
 
     /**
@@ -591,8 +591,8 @@ class PanelButton extends PanelMenu.Button {
         }
         if (this.menuSlider.get_parent() == null) {
             this.menuBox.insert_child_above(this.menuSlider, this.menuLabels);
+            debugLog("Added menu slider");
         }
-        debugLog("Added menu slider");
     }
 
     /**
@@ -653,8 +653,8 @@ class PanelButton extends PanelMenu.Button {
         }
         if (this.menuControls.get_parent() == null) {
             this.menuBox.add_child(this.menuControls);
+            debugLog("Added menu controls");
         }
-        debugLog("Added menu controls");
     }
 
     /**
@@ -703,9 +703,9 @@ class PanelButton extends PanelMenu.Button {
             this.buttonBox.replace_child(this.buttonIcon, icon);
         } else {
             this.buttonBox.insert_child_at_index(icon, index);
+            debugLog("Added icon");
         }
         this.buttonIcon = icon;
-        debugLog("Added icon");
     }
 
     /**
@@ -725,9 +725,9 @@ class PanelButton extends PanelMenu.Button {
             this.buttonBox.replace_child(this.buttonLabel, label);
         } else {
             this.buttonBox.insert_child_at_index(label, index);
+            debugLog("Added label");
         }
         this.buttonLabel = label;
-        debugLog("Added label");
     }
 
     /**
@@ -808,8 +808,8 @@ class PanelButton extends PanelMenu.Button {
         }
         if (this.buttonControls.get_parent() == null) {
             this.buttonBox.insert_child_at_index(this.buttonControls, index);
+            debugLog("Added controls");
         }
-        debugLog("Added controls");
     }
 
     /**


### PR DESCRIPTION
* Stops automatically setting the active player when adding a new player.
* Refines debug logging so logs only appear when UI elements are actually added, not just replaced.
