### PR TITLE
Remove left click delay without configured double click

### DIFF
--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -999,11 +999,16 @@ class PanelButton extends PanelMenu.Button {
                 this.doMouseAction(this.extension.mouseActionDouble);
                 return Clutter.EVENT_STOP;
             }
-            this.doubleTapSourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+            if (this.extension.mouseActionDouble !== MouseActions.NONE) {
+                this.doubleTapSourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+                    this.doubleTapSourceId = null;
+                    this.doMouseAction(action);
+                    return GLib.SOURCE_REMOVE;
+                });
+            } else {
                 this.doubleTapSourceId = null;
-                this.doMouseAction(this.extension.mouseActionLeft);
-                return GLib.SOURCE_REMOVE;
-            });
+                this.doMouseAction(action);
+            }
             return Clutter.EVENT_STOP;
         });
 
@@ -1024,11 +1029,16 @@ class PanelButton extends PanelMenu.Button {
                     this.doMouseAction(this.extension.mouseActionDouble);
                     return Clutter.EVENT_STOP;
                 }
-                this.doubleTapSourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+                if (this.extension.mouseActionDouble !== MouseActions.NONE) {
+                    this.doubleTapSourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+                        this.doubleTapSourceId = null;
+                        this.doMouseAction(this.extension.mouseActionLeft);
+                        return GLib.SOURCE_REMOVE;
+                    });
+                } else {
                     this.doubleTapSourceId = null;
                     this.doMouseAction(this.extension.mouseActionLeft);
-                    return GLib.SOURCE_REMOVE;
-                });
+                }
             }
             return Clutter.EVENT_STOP;
         });


### PR DESCRIPTION
There is a delay of 250ms when the left click is configured to anything but the default. This removes the delay when it is safe to do so (no double click action is configured).

Unrelated, but left click seems to always open the popup, even before my changes. I tried fixing but I'm a bit out of my depth here. As far as I can tell, the changes in this PR don't cause that issue though!