### PR TITLE
fix: sanitize newline characters in panel button's label text

### DIFF
--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -902,7 +902,7 @@ class PanelButton extends PanelMenu.Button {
                 labelTextElements.push(labelElement);
             }
         }
-        return labelTextElements.join(" ");
+        return labelTextElements.join(" ").replace(/[\r\n]+/g, " ");
     }
 
     /**


### PR DESCRIPTION
For some reasons, several music apps will contain newline characters in their MPRIS data, which results in bad panel looking.

This PR solves the problem by replacing them with a space.