### PR TITLE
Fix: Update Clutter.Image API usage for GNOME 46 compatibility (fixes #282)

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -510,9 +510,7 @@ export default class MediaControls extends Extension {
      * @returns {Promise<boolean>}
      */
     async initWatchProxy() {
-        this.watchProxy = await createDbusProxy(this.watchIfaceInfo, DBUS_IFACE_NAME, DBUS_OBJECT_PATH).catch(
-            errorLog,
-        );
+        this.watchProxy = await createDbusProxy(this.watchIfaceInfo, DBUS_IFACE_NAME, DBUS_OBJECT_PATH).catch(errorLog);
         if (this.watchProxy == null) {
             return false;
         }
@@ -671,7 +669,9 @@ export default class MediaControls extends Extension {
      */
     updateMediaNotificationVisiblity(shouldReset = false) {
         const MprisSource = Mpris.MprisSource ?? Mpris.MediaSection;
-        const mediaSource = Main.panel.statusArea.dateMenu._messageList._messageView?._mediaSource ?? Main.panel.statusArea.dateMenu._messageList._mediaSection;
+        const mediaSource =
+            Main.panel.statusArea.dateMenu._messageList._messageView?._mediaSource ??
+            Main.panel.statusArea.dateMenu._messageList._mediaSection;
 
         if (this.mediaSectionAddFunc && (shouldReset || this.hideMediaNotification === false)) {
             MprisSource.prototype._addPlayer = this.mediaSectionAddFunc;
@@ -679,14 +679,10 @@ export default class MediaControls extends Extension {
             mediaSource._onProxyReady();
         } else {
             this.mediaSectionAddFunc = MprisSource.prototype._addPlayer;
-            MprisSource.prototype._addPlayer = function() { };
+            MprisSource.prototype._addPlayer = function () {};
             if (mediaSource._players != null) {
                 for (const player of mediaSource._players.values()) {
-                    mediaSource._onNameOwnerChanged(
-                        null,
-                        null,
-                        [player._busName, player._busName, ""],
-                    );
+                    mediaSource._onNameOwnerChanged(null, null, [player._busName, player._busName, ""]);
                 }
             }
         }

--- a/src/helpers/shell/PanelButton.js
+++ b/src/helpers/shell/PanelButton.js
@@ -311,7 +311,7 @@ class PanelButton extends PanelMenu.Button {
     addMenuPlayers() {
         if (this.menuPlayers == null) {
             this.menuPlayers = new St.BoxLayout({
-                vertical: true
+                vertical: true,
             });
         }
         if (this.menuPlayersTextBox == null) {
@@ -517,8 +517,7 @@ class PanelButton extends PanelMenu.Button {
                 const height = width / aspectRatio;
                 const format = pixbuf.hasAlpha ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888;
                 const image = /** @type {St.ImageContent} */ (St.ImageContent.new_with_preferred_size(width, height));
-                const context = global.stage.context.get_backend().get_cogl_context();
-                image.set_bytes(context, pixbuf.pixelBytes, format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
+                image.set_bytes(pixbuf.pixelBytes, format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
                 this.menuImage.iconSize = -1;
                 this.menuImage.gicon = null;
                 this.menuImage.width = width;
@@ -547,7 +546,7 @@ class PanelButton extends PanelMenu.Button {
     addMenuLabels() {
         if (this.menuLabels == null) {
             this.menuLabels = new St.BoxLayout({
-                vertical: true
+                vertical: true,
             });
         }
         if (this.menuLabelTitle != null) {
@@ -632,8 +631,8 @@ class PanelButton extends PanelMenu.Button {
                 this.playerProxy.loopStatus === LoopStatus.NONE
                     ? ControlIconOptions.LOOP_NONE
                     : this.playerProxy.loopStatus === LoopStatus.TRACK
-                        ? ControlIconOptions.LOOP_TRACK
-                        : ControlIconOptions.LOOP_PLAYLIST,
+                      ? ControlIconOptions.LOOP_TRACK
+                      : ControlIconOptions.LOOP_PLAYLIST,
                 this.playerProxy.loopStatus != null,
                 this.playerProxy.toggleLoop.bind(this.playerProxy),
             );

--- a/src/helpers/shell/ScrollingLabel.js
+++ b/src/helpers/shell/ScrollingLabel.js
@@ -4,7 +4,6 @@ import Pango from "gi://Pango";
 import St from "gi://St";
 import { debugLog } from "../../utils/common.js";
 
-
 /**
  * @typedef {Object} ScrollingLabelParams
  * @property {string} text
@@ -304,7 +303,7 @@ class ScrollingLabel extends St.ScrollView {
      * @returns {void}
      */
     processLabelWidth() {
-        debugLog(this.label.width, this.labelWidth)
+        debugLog(this.label.width, this.labelWidth);
         const isLabelWider = this.label.width > this.labelWidth && this.labelWidth > 0;
         if (isLabelWider && this.isScrolling) {
             this.initScrolling();


### PR DESCRIPTION
Fixes the 'No Cover Art' issue on Ubuntu 24.04 (GNOME 46). The global.stage.context is deprecated, and Clutter.Image.set_bytes no longer accepts the context argument in GNOME 46. Tested on Ubuntu 24.04. Fixes #282 