### PR TITLE
Support GNOME shell version 50

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,5 +6,5 @@
   "settings-schema": "org.gnome.shell.extensions.mediacontrols",
   "gettext-domain": "mediacontrols@cliffniff.github.com",
   "version-name": "2.4.4",
-  "shell-version": ["46", "47", "48", "49"]
+  "shell-version": ["46", "47", "48", "49", "50"]
 }


### PR DESCRIPTION
Gnome shell 50 has been released. Looking over https://gjs.guide/extensions/upgrading/gnome-shell-50.html no actual code changes seem to be needed by this extension. So just add support for version 50 in the metadata.

Closes  #302